### PR TITLE
13

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ go install github.com/simonmittag/p0d/cmd/p0d@latest && p0d -h
 
 ## Usage Samples
 
-Run for 30 seconds with 10 parallel connections/threads against local server
+Run for 30 seconds with 10 concurrent connections against local server
 ```
-λ p0d -d 30 -t 10 -c 10 http://localhost:8080/path
+λ p0d -d 30 -c 10 http://localhost:8080/path
 ```
 
 Run in http/2 mode against local server and save output to `log.json`
@@ -55,13 +55,13 @@ Run with config file
   -O string
         save detailed JSON output to file
   -c int
-        maximum amount of parallel TCP connections used (default 1)
+        maximum amount of concurrent TCP connections used (default 1)
   -d int
         time in seconds to run p0d (default 10)
-  -h    print usage instructions
-  -t int
-        amount of parallel execution threads (default 1)
-  -v    print version
+  -h    
+        print usage instructions
+  -v    
+        print version
 ```
 
 ### Config file reference
@@ -71,8 +71,7 @@ Run with config file
 exec:
   mode: binary
   durationSeconds: 10
-  threads: 1
-  connections: 1
+  concurrency: 1
   logsampling: 1
 req:
   method: POST
@@ -95,13 +94,9 @@ run pod for `n` seconds. Defaults to `10`
 #### exec.dialTimeoutSeconds
 give up connecting to upstream resource after `n` seconds. Defaults to `3`
 
-#### exec.threads
-use `n` threads to make parallel calls to the server. Defaults to `1`
-
-#### exec.connections
-use a pool of maximum `n` connections. Defaults to `1`. Make sure your OS supports sufficient open file descriptors
-before settings this to a very high value. Set this to a similar size as `exec.threads` to avoid large amounts of
-threads competing for few connection resources.
+#### exec.concurrency
+use a pool of maximum `n` concurrent TCP connections. Defaults to `1`. Make sure your OS supports
+sufficient open file descriptors before settings this to a very high value. 
 
 #### exec.spacingMillis
 artificial spacing in milliseconds, introduced before sending each request. Defaults to `0`

--- a/cmd/p0d/main.go
+++ b/cmd/p0d/main.go
@@ -23,8 +23,7 @@ func main() {
 
 	C := flag.String("C", "", "load configuration from yml file")
 	O := flag.String("O", "", "save detailed JSON output to file")
-	t := flag.Int("t", 1, "amount of parallel threads")
-	c := flag.Int("c", 1, "maximum amount of parallel TCP connections used")
+	c := flag.Int("c", 1, "maximum amount of concurrent TCP connections used")
 	d := flag.Int("d", 10, "time in seconds to run p0d")
 	H := flag.String("H", "1.1", "http version to use. Values are 1.1 and 2 (which works only with "+
 		"TLS URLs). Defaults to 1.1")
@@ -48,7 +47,7 @@ func main() {
 	var pod *p0d.P0d
 	switch mode {
 	case Cli:
-		pod = p0d.NewP0dWithValues(*t, *c, *d, u, *H, *O)
+		pod = p0d.NewP0dWithValues(*c, *d, u, *H, *O)
 		pod.Race()
 	case File:
 		pod = p0d.NewP0dFromFile(*C, *O)

--- a/cmd/p0d/main.go
+++ b/cmd/p0d/main.go
@@ -22,7 +22,7 @@ func main() {
 	var mode Mode
 
 	C := flag.String("C", "", "load configuration from yml file")
-	O := flag.String("O", "", "save detailed JSON output to file")
+	O := flag.String("O", "", "save detailed output to json file")
 	c := flag.Int("c", 1, "maximum amount of concurrent TCP connections used")
 	d := flag.Int("d", 10, "time in seconds to run p0d")
 	H := flag.String("H", "1.1", "http version to use. Values are 1.1 and 2 (which works only with "+

--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/logrusorgru/aurora"
 	"golang.org/x/net/http2"
 	"io/ioutil"
+	"math"
 	"net"
 	"net/http"
 	"os"
@@ -39,6 +40,7 @@ type Res struct {
 type Exec struct {
 	Mode               string
 	DurationSeconds    int
+	RampSeconds        int
 	Concurrency        int
 	DialTimeoutSeconds int64
 	LogSampling        float32
@@ -87,6 +89,18 @@ func (cfg *Config) validate() *Config {
 	}
 	if cfg.Exec.DurationSeconds == 0 {
 		cfg.Exec.DurationSeconds = 10
+	} else {
+		if cfg.Exec.DurationSeconds < 3 {
+			cfg.panic("duration cannot be less than 3 seconds")
+		}
+	}
+
+	if cfg.Exec.RampSeconds == 0 {
+		cfg.Exec.RampSeconds = int(math.Ceil(float64(cfg.Exec.DurationSeconds) / 10))
+	} else {
+		if float64(cfg.Exec.RampSeconds) > (float64(cfg.Exec.DurationSeconds) / 2) {
+			cfg.panic("ramp time cannot be longer than half the duration")
+		}
 	}
 	if cfg.Exec.DialTimeoutSeconds == 0 {
 		cfg.Exec.DialTimeoutSeconds = 3

--- a/config.go
+++ b/config.go
@@ -213,6 +213,8 @@ func (cfg *Config) hasContentType(contentType string) bool {
 	return true
 }
 
+const httpIdleTimeout = time.Duration(1) * time.Second
+
 func (cfg Config) scaffoldHttpClient() *http.Client {
 	tlsc := &tls.Config{
 		MinVersion:         tls.VersionTLS11,
@@ -232,7 +234,7 @@ func (cfg Config) scaffoldHttpClient() *http.Client {
 		MaxConnsPerHost:     cfg.Exec.Concurrency,
 		MaxIdleConns:        cfg.Exec.Concurrency,
 		MaxIdleConnsPerHost: cfg.Exec.Concurrency,
-		IdleConnTimeout:     time.Duration(cfg.Exec.DialTimeoutSeconds) * time.Second,
+		IdleConnTimeout:     httpIdleTimeout,
 		TLSNextProto:        make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
 	}
 

--- a/config.go
+++ b/config.go
@@ -39,8 +39,7 @@ type Res struct {
 type Exec struct {
 	Mode               string
 	DurationSeconds    int
-	Threads            int
-	Connections        int
+	Concurrency        int
 	DialTimeoutSeconds int64
 	LogSampling        float32
 	SpacingMillis      int64
@@ -83,11 +82,8 @@ func (cfg *Config) validate() *Config {
 		cfg.Req.Method = "GET"
 	}
 
-	if cfg.Exec.Threads == 0 {
-		cfg.Exec.Threads = 1
-	}
-	if cfg.Exec.Connections == 0 {
-		cfg.Exec.Connections = 1
+	if cfg.Exec.Concurrency == 0 {
+		cfg.Exec.Concurrency = 1
 	}
 	if cfg.Exec.DurationSeconds == 0 {
 		cfg.Exec.DurationSeconds = 10
@@ -233,15 +229,15 @@ func (cfg Config) scaffoldHttpClient() *http.Client {
 		//TLS handshake timeout is the same as connection timeout
 		TLSHandshakeTimeout: time.Duration(cfg.Exec.DialTimeoutSeconds) * time.Second,
 		TLSClientConfig:     tlsc,
-		MaxConnsPerHost:     cfg.Exec.Connections,
-		MaxIdleConns:        cfg.Exec.Connections,
-		MaxIdleConnsPerHost: cfg.Exec.Connections,
+		MaxConnsPerHost:     cfg.Exec.Concurrency,
+		MaxIdleConns:        cfg.Exec.Concurrency,
+		MaxIdleConnsPerHost: cfg.Exec.Concurrency,
 		IdleConnTimeout:     time.Duration(cfg.Exec.DialTimeoutSeconds) * time.Second,
 		TLSNextProto:        make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
 	}
 
 	//see https://stackoverflow.com/questions/57683132/turning-off-connection-pool-for-go-http-client
-	if cfg.Exec.Connections == UNLIMITED {
+	if cfg.Exec.Concurrency == UNLIMITED {
 		t.DisableKeepAlives = true
 		logv(Yellow("transport connection pool disabled for http/1.1"))
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -32,6 +32,9 @@ func TestEmptyConfigValidate(t *testing.T) {
 	if got.Exec.DurationSeconds != 10 {
 		t.Error("invalid default duration seconds")
 	}
+	if got.Exec.RampSeconds != 1 {
+		t.Error("invalid default ramp seconds")
+	}
 	if got.Exec.LogSampling != 1 {
 		t.Error("invalid default logsampling")
 	}
@@ -41,6 +44,51 @@ func TestEmptyConfigValidate(t *testing.T) {
 	if got.Exec.Concurrency != 1 {
 		t.Error("invalid default threads")
 	}
+}
+
+func TestValidRamptime(t *testing.T) {
+	cfg := Config{
+		Req: Req{
+			Url: "http://localhost:8080/blah",
+		},
+	}
+	tDr := func(d int, r int, w int) {
+		cfg.Exec.DurationSeconds = d
+		cfg.Exec.RampSeconds = r
+		cfg.validate()
+		got := cfg.Exec.RampSeconds
+		if w != got {
+			t.Errorf("invalid ramp time got %v want %v", got, w)
+		}
+	}
+
+	tDr(60, 30, 30)
+	tDr(30, 15, 15)
+	tDr(30, 0, 3)
+	tDr(10, 0, 1)
+	tDr(9, 0, 1)
+	tDr(8, 0, 1)
+	tDr(7, 0, 1)
+	tDr(6, 0, 1)
+	tDr(5, 0, 1)
+	tDr(4, 0, 1)
+	tDr(3, 0, 1)
+	tDr(10, 3, 3)
+	tDr(9, 3, 3)
+	tDr(8, 3, 3)
+	tDr(7, 3, 3)
+	tDr(6, 3, 3)
+	tDr(5, 2, 2)
+	tDr(4, 2, 2)
+	tDr(3, 1, 1)
+	tDr(10, 1, 1)
+	tDr(9, 1, 1)
+	tDr(8, 1, 1)
+	tDr(7, 1, 1)
+	tDr(6, 1, 1)
+	tDr(5, 1, 1)
+	tDr(4, 1, 1)
+	tDr(3, 1, 1)
 }
 
 func TestLoadConfigFromFile(t *testing.T) {

--- a/config_test.go
+++ b/config_test.go
@@ -165,7 +165,7 @@ func TestPostConfigValidate(t *testing.T) {
 func TestScaffoldHTTPClient(t *testing.T) {
 	cfg := loadConfigFromFile("./examples/config_get.yml")
 
-	h := cfg.scaffoldHttpClient()
+	h := cfg.scaffoldHttpClient(cfg.Exec.Concurrency)
 	if h.Transport == nil {
 		t.Error("http client not configured")
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -4,6 +4,33 @@ import (
 	"testing"
 )
 
+func TestGetRemotePort(t *testing.T) {
+	cfg := Config{
+		Req: Req{
+			Url: "http://localhost:8080/blah",
+		},
+	}
+	_ = cfg.validate()
+
+	if cfg.getRemotePort() != 8080 {
+		t.Error("invalid remote port")
+	}
+
+	cfg.Req.Url = "http://localhost/blah"
+	_ = cfg.validate()
+
+	if cfg.getRemotePort() != 80 {
+		t.Error("invalid remote port")
+	}
+
+	cfg.Req.Url = "https://localhost/blah"
+	_ = cfg.validate()
+
+	if cfg.getRemotePort() != 443 {
+		t.Error("invalid remote port")
+	}
+}
+
 func TestEmptyConfigValidate(t *testing.T) {
 	cfg := Config{
 		Req: Req{
@@ -11,6 +38,7 @@ func TestEmptyConfigValidate(t *testing.T) {
 		},
 	}
 	got := cfg.validate()
+
 	if got.Res.Code != 200 {
 		t.Error("invalid default res code")
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -38,14 +38,8 @@ func TestEmptyConfigValidate(t *testing.T) {
 	if got.Exec.SpacingMillis != 0 {
 		t.Error("invalid default spacing millis")
 	}
-	if got.Exec.Threads != 1 {
+	if got.Exec.Concurrency != 1 {
 		t.Error("invalid default threads")
-	}
-	if got.Exec.Connections != 1 {
-		t.Error("invalid default connections")
-	}
-	if got.Exec.Connections != 1 {
-		t.Error("invalid default connections")
 	}
 }
 

--- a/examples/config_formpost.yml
+++ b/examples/config_formpost.yml
@@ -1,6 +1,7 @@
 ---
 exec:
   durationSeconds: 30
+  rampSeconds: 3
   concurrency: 128
 req:
   method: POST

--- a/examples/config_formpost.yml
+++ b/examples/config_formpost.yml
@@ -1,8 +1,7 @@
 ---
 exec:
   durationSeconds: 30
-  threads: 128
-  connections: 128
+  concurrency: 128
 req:
   method: POST
   url: http://localhost:60083/mse6/post

--- a/examples/config_formpost_multipart.yml
+++ b/examples/config_formpost_multipart.yml
@@ -1,7 +1,8 @@
 ---
 exec:
-  durationSeconds: 5
-  concurrency: 5
+  durationSeconds: 3
+  rampSeconds: 1
+  concurrency: 128
 req:
   method: POST
   url: http://localhost:60083/mse6/formpost

--- a/examples/config_formpost_multipart.yml
+++ b/examples/config_formpost_multipart.yml
@@ -1,8 +1,8 @@
 ---
 exec:
-  durationSeconds: 10
-  threads: 128
-  connections: 128
+  durationSeconds: 5
+  threads: 5
+  connections: 5
 req:
   method: POST
   url: http://localhost:60083/mse6/formpost

--- a/examples/config_formpost_multipart.yml
+++ b/examples/config_formpost_multipart.yml
@@ -1,8 +1,7 @@
 ---
 exec:
   durationSeconds: 5
-  threads: 5
-  connections: 5
+  concurrency: 5
 req:
   method: POST
   url: http://localhost:60083/mse6/formpost

--- a/examples/config_get.yml
+++ b/examples/config_get.yml
@@ -2,7 +2,7 @@
 exec:
   mode: binary
   durationSeconds: 30
-  rampSeconds: 14
+  rampSeconds: 3
   concurrency: 128
   logsampling: 0.1
   httpVersion: 2

--- a/examples/config_get.yml
+++ b/examples/config_get.yml
@@ -2,6 +2,7 @@
 exec:
   mode: binary
   durationSeconds: 30
+  rampSeconds: 3
   concurrency: 128
   logsampling: 0.1
   httpVersion: 2

--- a/examples/config_get.yml
+++ b/examples/config_get.yml
@@ -2,7 +2,7 @@
 exec:
   mode: binary
   durationSeconds: 30
-  rampSeconds: 3
+  rampSeconds: 14
   concurrency: 128
   logsampling: 0.1
   httpVersion: 2

--- a/examples/config_get.yml
+++ b/examples/config_get.yml
@@ -2,8 +2,7 @@
 exec:
   mode: binary
   durationSeconds: 30
-  threads: 128
-  connections: 128
+  concurrency: 128
   logsampling: 0.1
   httpVersion: 2
 req:

--- a/examples/config_post.yml
+++ b/examples/config_post.yml
@@ -1,8 +1,7 @@
 ---
 exec:
   durationSeconds: 30
-  threads: 128
-  connections: 128
+  concurrency: 128
   logsampling: 0.01
 req:
   method: POST

--- a/examples/config_post.yml
+++ b/examples/config_post.yml
@@ -1,6 +1,7 @@
 ---
 exec:
   durationSeconds: 30
+  rampSeconds: 3
   concurrency: 128
   logsampling: 0.01
 req:

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,13 @@ require (
 	github.com/gosuri/uilive v0.0.4
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/logrusorgru/aurora v2.0.3+incompatible
+	github.com/simonmittag/procspy v0.0.0-20191119070947-e8cf3f846a67
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2
 )
 
 require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
-	github.com/simonmittag/procspy v0.0.0-20191119070947-e8cf3f846a67 // indirect
+	github.com/weaveworks/procspy v0.0.0-20150706124340-cb970aa190c3 // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	golang.org/x/text v0.3.6 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/p0d.go
+++ b/p0d.go
@@ -401,7 +401,7 @@ func (p *P0d) closeLiveWritersAndSummarize() {
 	p.logSummary()
 
 	if len(p.Output) > 0 {
-		log("finalizing log file '%s'", Yellow(p.Output))
+		log("finalizing out file '%s'", Yellow(p.Output))
 		j, je := json.MarshalIndent(p, "", "  ")
 		p.outFileCheckWrite(je)
 		_, we := p.outFile.Write(j)
@@ -443,7 +443,7 @@ func (p *P0d) initLog() {
 			Yellow(durafmt.Parse(time.Duration(p.Config.Exec.SpacingMillis)*time.Millisecond).LimitFirstN(2).String()))
 	}
 	if len(p.Output) > 0 {
-		log("log sampling rate: %s%s", Yellow(FGroup(int64(100*p.Config.Exec.LogSampling))), Yellow("%"))
+		log("out file sampling rate: %s%s", Yellow(FGroup(int64(100*p.Config.Exec.LogSampling))), Yellow("%"))
 	}
 	fmt.Printf(timefmt("%s %s"), Yellow(p.Config.Req.Method), Yellow(p.Config.Req.Url))
 }

--- a/p0d.go
+++ b/p0d.go
@@ -638,7 +638,7 @@ func (p *P0d) initOSStats() {
 
 func (p *P0d) doOSSStats() {
 	oss := NewOSStats(p.PID)
-	oss.updateOpenConns()
+	oss.updateOpenConns(p.Config)
 	p.OSStats = append(p.OSStats, *oss)
 }
 

--- a/p0d.go
+++ b/p0d.go
@@ -369,7 +369,7 @@ func (p *P0d) logLive() {
 	fmt.Fprintf(lw[i], timefmt("%s"), p.bar.render(elpsd, p))
 	i++
 	oss := p.latestOSStats()
-	fmt.Fprintf(lw[i], timefmt("TCP open conns: %s"), Cyan(FGroup(int64(oss.PidOpenConns))))
+	fmt.Fprintf(lw[i], timefmt("TCP open conns: %s%s%s"), Cyan(FGroup(int64(oss.PidOpenConns))), Cyan("/"), Cyan(FGroup(int64(p.Config.Exec.Connections))))
 	i++
 	fmt.Fprintf(lw[i], timefmt("HTTP req: %s"), Cyan(FGroup(int64(p.ReqStats.ReqAtmpts))))
 	i++
@@ -476,7 +476,7 @@ func (p *P0d) initOSStats() {
 			oss := NewOSStats()
 			oss.updateOpenConns()
 			p.OSStats = append(p.OSStats, *oss)
-			time.Sleep(time.Millisecond * 100)
+			time.Sleep(time.Millisecond * 250)
 		}
 	}()
 }

--- a/p0d.go
+++ b/p0d.go
@@ -255,7 +255,14 @@ func (p *P0d) initReqAtmpts(ras chan ReqAtmpt) {
 			go p.doReqAtmpts(i, ras, p.stopThreads[i])
 		}
 		//can we do this so main only starts after concurrency is reached? what if it never does? it's stuck on ramping
-		p.setTimerPhase(Main)
+	MainUpdate:
+		for {
+			if p.getOSStats().PidOpenConns >= p.Config.Exec.Concurrency {
+				p.setTimerPhase(Main)
+				break MainUpdate
+			}
+			time.Sleep(time.Millisecond * 100)
+		}
 	}()
 }
 

--- a/p0d.go
+++ b/p0d.go
@@ -23,7 +23,7 @@ import (
 	"time"
 )
 
-const Version string = "v0.2.6"
+const Version string = "v0.2.7"
 
 type P0d struct {
 	ID             string

--- a/p0d.go
+++ b/p0d.go
@@ -24,7 +24,7 @@ import (
 	"time"
 )
 
-const Version string = "v0.2.7"
+const Version string = "v0.2.8"
 const ua = "User-Agent"
 const N = ""
 const ct = "Content-Type"
@@ -274,6 +274,8 @@ func (p *P0d) staggerThreadsDuration() time.Duration {
 }
 
 func (p *P0d) doReqAtmpts(i int, ras chan<- ReqAtmpt, done <-chan struct{}) {
+	p.client[i].CloseIdleConnections()
+
 ReqAtmpt:
 	for {
 		select {

--- a/p0d.go
+++ b/p0d.go
@@ -632,7 +632,7 @@ func (p *P0d) initOSStats() {
 	go func() {
 		for {
 			p.doOSSStats()
-			time.Sleep(time.Millisecond * 250)
+			time.Sleep(time.Millisecond * 1000)
 		}
 	}()
 }

--- a/p0d.go
+++ b/p0d.go
@@ -23,7 +23,7 @@ import (
 	"time"
 )
 
-const Version string = "v0.2.5"
+const Version string = "v0.2.6"
 
 type P0d struct {
 	ID             string

--- a/p0d.go
+++ b/p0d.go
@@ -464,7 +464,7 @@ func (p *P0d) doLogLive() {
 			connMsg += Cyan(" (drained)").String()
 		}
 	} else if oss.PidOpenConns < p.Config.Exec.Concurrency {
-		connMsg += Cyan(" (pooling)").String()
+		connMsg += Cyan(" (ramping up)").String()
 	}
 	fmt.Fprintf(lw[i], timefmt(connMsg), Cyan(FGroup(int64(oss.PidOpenConns))), Cyan("/"), Cyan(FGroup(int64(p.Config.Exec.Concurrency))))
 	i++

--- a/p0d.go
+++ b/p0d.go
@@ -650,7 +650,6 @@ func (p *P0d) setTimerPhase(phase TimerPhase) {
 	if phase > p.TimerPhase {
 		p.TimerPhase = phase
 	}
-	p.TimerPhase = p.TimerPhase & phase
 }
 
 func (p *P0d) isTimerPhase(phase TimerPhase) bool {

--- a/p0d.go
+++ b/p0d.go
@@ -472,7 +472,7 @@ func (p *P0d) doLogLive() {
 	i++
 	fmt.Fprintf(lw[i], timefmt("roundtrip throughput: %s%s"), Cyan(FGroup(int64(p.ReqStats.ReqAtmptsPSec))), Cyan("/s"))
 	i++
-	fmt.Fprintf(lw[i], timefmt("roundtrip latency: %s%s"), Cyan(FGroup(int64(p.ReqStats.MeanElpsdAtmptLatencyNs.Milliseconds()))), Cyan("ms"))
+	fmt.Fprintf(lw[i], timefmt("mean roundtrip latency: %s%s"), Cyan(FGroup(int64(p.ReqStats.MeanElpsdAtmptLatencyNs.Milliseconds()))), Cyan("ms"))
 	i++
 	fmt.Fprintf(lw[i], timefmt("bytes read: %s"), Cyan(p.Config.byteCount(p.ReqStats.SumBytesRead)))
 	i++

--- a/p0d.go
+++ b/p0d.go
@@ -19,6 +19,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 )
@@ -636,10 +637,14 @@ func (p *P0d) initOSStats() {
 	}()
 }
 
+var osMutex = sync.Mutex{}
+
 func (p *P0d) doOSSStats() {
+	osMutex.Lock()
 	oss := NewOSStats(p.PID)
 	oss.updateOpenConns(p.Config)
 	p.OSStats = append(p.OSStats, *oss)
+	osMutex.Unlock()
 }
 
 func (p *P0d) getOSStats() OSStats {

--- a/p0d.go
+++ b/p0d.go
@@ -632,7 +632,7 @@ func (p *P0d) initOSStats() {
 	go func() {
 		for {
 			p.doOSSStats()
-			time.Sleep(time.Millisecond * 1000)
+			time.Sleep(time.Millisecond * 250)
 		}
 	}()
 }

--- a/p0d_test.go
+++ b/p0d_test.go
@@ -77,7 +77,7 @@ func TestNewP0dWithValues(t *testing.T) {
 
 func TestLogBootstrap(t *testing.T) {
 	p := NewP0dFromFile("./examples/config_get.yml", "")
-	p.logBootstrap()
+	p.initLog()
 }
 
 func TestLogSummary(t *testing.T) {
@@ -100,7 +100,7 @@ func TestDoReqAtmpt(t *testing.T) {
 	ras := make(chan ReqAtmpt, 65535)
 	done := make(chan struct{})
 	//fire this off in goroutine
-	go p.doReqAtmpt(ras, done)
+	go p.doReqAtmpts(ras, done)
 
 	//then wait for signal from completed reqAtmpt.
 	ra := <-ras

--- a/p0d_test.go
+++ b/p0d_test.go
@@ -13,17 +13,14 @@ func TestNewP0dFromFile(t *testing.T) {
 	if p.Config.Res.Code != 200 {
 		t.Error("incorrect response code")
 	}
-	if p.Config.Exec.Connections != 128 {
-		t.Error("incorrect connections")
+	if p.Config.Exec.Concurrency != 128 {
+		t.Error("incorrect concurrency")
 	}
 	if p.Config.Exec.DurationSeconds != 30 {
 		t.Error("incorrect duration seconds")
 	}
 	if p.Config.Exec.DialTimeoutSeconds != 3 {
 		t.Error("incorrect dialtimeout seconds")
-	}
-	if p.Config.Exec.Threads != 128 {
-		t.Error("incorrect threads")
 	}
 	if p.Config.Req.Method != "GET" {
 		t.Error("incorrect method")
@@ -40,22 +37,19 @@ func TestNewP0dFromFile(t *testing.T) {
 }
 
 func TestNewP0dWithValues(t *testing.T) {
-	p := NewP0dWithValues(8, 7, 6, "http://localhost/", "1.1", "")
+	p := NewP0dWithValues(7, 6, "http://localhost/", "1.1", "")
 
 	if p.Config.Res.Code != 200 {
 		t.Error("incorrect response code")
 	}
-	if p.Config.Exec.Connections != 7 {
-		t.Error("incorrect connections")
+	if p.Config.Exec.Concurrency != 7 {
+		t.Error("incorrect concurrency")
 	}
 	if p.Config.Exec.DurationSeconds != 6 {
 		t.Error("incorrect duration seconds")
 	}
 	if p.Config.Exec.DialTimeoutSeconds != 3 {
 		t.Error("incorrect dialtimeout seconds")
-	}
-	if p.Config.Exec.Threads != 8 {
-		t.Error("incorrect threads")
 	}
 	if p.Config.Exec.HttpVersion != 1.1 {
 		t.Error("incorrect http version")

--- a/p0d_test.go
+++ b/p0d_test.go
@@ -94,7 +94,7 @@ func TestDoReqAtmpt(t *testing.T) {
 	ras := make(chan ReqAtmpt, 65535)
 	done := make(chan struct{})
 	//fire this off in goroutine
-	go p.doReqAtmpts(ras, done)
+	go p.doReqAtmpts(0, ras, done)
 
 	//then wait for signal from completed reqAtmpt.
 	ra := <-ras

--- a/p0d_test.go
+++ b/p0d_test.go
@@ -146,5 +146,95 @@ func TestRaceWithOutput(t *testing.T) {
 
 	//for good measure
 	os.Remove(p.Output)
+}
 
+func TestTimerPhase(t *testing.T) {
+	p := P0d{TimerPhase: Bootstrap}
+
+	p.setTimerPhase(Bootstrap)
+	if !p.isTimerPhase(Bootstrap) {
+		t.Error("should have bootstrap")
+	}
+
+	p.setTimerPhase(RampUp)
+	if p.isTimerPhase(Bootstrap) {
+		t.Error("should NOT have bootstrap")
+	}
+	if !p.isTimerPhase(RampUp) {
+		t.Error("should have rampup")
+	}
+
+	p.setTimerPhase(RampDown)
+	if p.isTimerPhase(Bootstrap) {
+		t.Error("should NOT have bootstrap")
+	}
+	if p.isTimerPhase(RampUp) {
+		t.Error("should NOT have rampup")
+	}
+	if !p.isTimerPhase(RampDown) {
+		t.Error("should have rampdown")
+	}
+
+	p.setTimerPhase(Draining)
+	if p.isTimerPhase(Bootstrap) {
+		t.Error("should NOT have bootstrap")
+	}
+	if p.isTimerPhase(RampUp) {
+		t.Error("should NOT have rampup")
+	}
+	if p.isTimerPhase(RampDown) {
+		t.Error("should NOT have rampdown")
+	}
+	if !p.isTimerPhase(Draining) {
+		t.Error("should have draining")
+	}
+
+	p.setTimerPhase(Drained)
+	if p.isTimerPhase(Bootstrap) {
+		t.Error("should NOT have bootstrap")
+	}
+	if p.isTimerPhase(RampUp) {
+		t.Error("should NOT have rampup")
+	}
+	if p.isTimerPhase(RampDown) {
+		t.Error("should NOT have rampdown")
+	}
+	if p.isTimerPhase(Draining) {
+		t.Error("should NOT have draining")
+	}
+	if !p.isTimerPhase(Drained) {
+		t.Error("should have drained")
+	}
+
+	p.setTimerPhase(Done)
+	if p.isTimerPhase(Bootstrap) {
+		t.Error("should NOT have bootstrap")
+	}
+	if p.isTimerPhase(RampUp) {
+		t.Error("should NOT have rampup")
+	}
+	if p.isTimerPhase(RampDown) {
+		t.Error("should NOT have rampdown")
+	}
+	if p.isTimerPhase(Draining) {
+		t.Error("should NOT have draining")
+	}
+	if p.isTimerPhase(Drained) {
+		t.Error("should NOT have drained")
+	}
+	if !p.isTimerPhase(Done) {
+		t.Error("should have done")
+	}
+
+	p2 := P0d{TimerPhase: RampUp}
+	p2.setTimerPhase(Done)
+	if p2.isTimerPhase(RampUp) {
+		t.Error("should NOT have rampup")
+	}
+	if p2.isTimerPhase(RampDown) {
+		t.Error("should NOT have rampdown")
+	}
+	if !p2.isTimerPhase(Done) {
+		t.Error("should have done")
+	}
 }

--- a/stats.go
+++ b/stats.go
@@ -3,7 +3,6 @@ package p0d
 import (
 	"github.com/simonmittag/procspy"
 	"math"
-	"os"
 	"time"
 )
 
@@ -56,26 +55,26 @@ type OSStats struct {
 	PidOpenConns int
 }
 
-func NewOSStats() *OSStats {
+func NewOSStats(pid int) *OSStats {
 	return &OSStats{
-		Pid:          os.Getpid(),
+		Pid:          pid,
 		Now:          time.Now(),
 		PidOpenConns: 0,
 	}
 }
 
 func (oss *OSStats) updateOpenConns() {
+	//TODO: this produces a 0 when it shouldn't. after signalling CTRL+C this often returns intermittent 0
 	cs, e := procspy.Connections(true)
 	if e != nil {
 		_ = e
-	}
-	d := 0
-	a := 0
-	for c := cs.Next(); c != nil; c = cs.Next() {
-		a++
-		if c.PID == uint(oss.Pid) {
-			d++
+	} else {
+		d := 0
+		for c := cs.Next(); c != nil; c = cs.Next() {
+			if c.PID == uint(oss.Pid) {
+				d++
+			}
 		}
+		oss.PidOpenConns = d
 	}
-	oss.PidOpenConns = d
 }

--- a/stats.go
+++ b/stats.go
@@ -87,17 +87,17 @@ func (oss *OSStats) updateOpenConns(cfg Config) {
 	} else {
 		d := 0
 		cm.Lock()
+		fmt.Print("\n---start conns---:")
 		for c := cs.Next(); c != nil; c = cs.Next() {
 			// fixes bug where pid connections to other network infra are reported as false positive, see:
 			// https://github.com/simonmittag/p0d/issues/31
 
-			fmt.Print("\n---start conns---: \n")
 			if c.PID == uint(oss.Pid) && c.RemotePort == cfg.getRemotePort() {
 				d++
-				fmt.Printf("\n\nconn: %v\n\n", c)
+				fmt.Printf("\nconn: %v", c)
 			}
-			fmt.Print("\n---stop conns---: \n")
 		}
+		fmt.Print("\n---stop conns---:")
 		cm.Unlock()
 		oss.PidOpenConns = d
 	}

--- a/stats.go
+++ b/stats.go
@@ -75,7 +75,7 @@ func NewOSStats(pid int) *OSStats {
 	}
 }
 
-func (oss *OSStats) updateOpenConns() {
+func (oss *OSStats) updateOpenConns(cfg Config) {
 	//TODO: this produces a 0 when it shouldn't. after signalling CTRL+C this often returns intermittent 0
 	cs, e := procspy.Connections(true)
 	if e != nil {
@@ -83,7 +83,9 @@ func (oss *OSStats) updateOpenConns() {
 	} else {
 		d := 0
 		for c := cs.Next(); c != nil; c = cs.Next() {
-			if c.PID == uint(oss.Pid) {
+			// fixes bug where pid connections to other network infra are reported as false positive, see:
+			// https://github.com/simonmittag/p0d/issues/31
+			if c.PID == uint(oss.Pid) && c.RemotePort == cfg.getRemotePort() {
 				d++
 			}
 		}

--- a/stats.go
+++ b/stats.go
@@ -1,10 +1,8 @@
 package p0d
 
 import (
-	"fmt"
 	"github.com/simonmittag/procspy"
 	"math"
-	"sync"
 	"time"
 )
 
@@ -77,8 +75,6 @@ func NewOSStats(pid int) *OSStats {
 	}
 }
 
-var cm = sync.Mutex{}
-
 func (oss *OSStats) updateOpenConns(cfg Config) {
 	//TODO: this produces a 0 when it shouldn't. after signalling CTRL+C this often returns intermittent 0
 	cs, e := procspy.Connections(true)
@@ -86,19 +82,13 @@ func (oss *OSStats) updateOpenConns(cfg Config) {
 		_ = e
 	} else {
 		d := 0
-		cm.Lock()
-		fmt.Print("\n---start conns---:")
 		for c := cs.Next(); c != nil; c = cs.Next() {
 			// fixes bug where pid connections to other network infra are reported as false positive, see:
 			// https://github.com/simonmittag/p0d/issues/31
-
 			if c.PID == uint(oss.Pid) && c.RemotePort == cfg.getRemotePort() {
 				d++
-				fmt.Printf("\nconn: %v", c)
 			}
 		}
-		fmt.Print("\n---stop conns---:")
-		cm.Unlock()
 		oss.PidOpenConns = d
 	}
 }

--- a/stats.go
+++ b/stats.go
@@ -11,10 +11,13 @@ type ReqStats struct {
 	Elpsd                    time.Duration
 	ReqAtmpts                int
 	ReqAtmptsPSec            int
+	MaxReqAtmptsPSec         int
 	SumBytesRead             int64
 	MeanBytesReadSec         int
+	MaxBytesReadSec          int
 	SumBytesWritten          int64
 	MeanBytesWrittenSec      int
+	MaxBytesWrittenSec       int
 	SumElpsdAtmptLatencyNs   time.Duration
 	MeanElpsdAtmptLatencyNs  time.Duration
 	SumMatchingResponseCodes int
@@ -28,12 +31,21 @@ func (s *ReqStats) update(atmpt ReqAtmpt, now time.Time, cfg Config) {
 	s.ReqAtmpts++
 	s.Elpsd = now.Sub(s.Start)
 	s.ReqAtmptsPSec = int(math.Floor(float64(s.ReqAtmpts) / s.Elpsd.Seconds()))
+	if s.ReqAtmptsPSec > s.MaxReqAtmptsPSec {
+		s.MaxReqAtmptsPSec = s.ReqAtmptsPSec
+	}
 
 	s.SumBytesRead += atmpt.ResBytes
 	s.MeanBytesReadSec = int(math.Floor(float64(s.SumBytesRead) / s.Elpsd.Seconds()))
+	if s.MeanBytesReadSec > s.MaxBytesReadSec {
+		s.MaxBytesReadSec = s.MeanBytesReadSec
+	}
 
 	s.SumBytesWritten += atmpt.ReqBytes
 	s.MeanBytesWrittenSec = int(math.Floor(float64(s.SumBytesWritten) / s.Elpsd.Seconds()))
+	if s.MeanBytesWrittenSec > s.MaxBytesWrittenSec {
+		s.MaxBytesWrittenSec = s.MeanBytesWrittenSec
+	}
 	s.SumElpsdAtmptLatencyNs += atmpt.ElpsdNs
 	s.MeanElpsdAtmptLatencyNs = s.SumElpsdAtmptLatencyNs / time.Duration(s.ReqAtmpts)
 

--- a/stats_test.go
+++ b/stats_test.go
@@ -106,13 +106,13 @@ func TestUpdateStats(t *testing.T) {
 }
 
 func TestUpdateOSStats(t *testing.T) {
-	oss := NewOSStats()
+	oss := NewOSStats(1)
 	oss.updateOpenConns()
 }
 
 func BenchmarkUpdateOpenConns(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		oss := NewOSStats()
+		oss := NewOSStats(1)
 		oss.updateOpenConns()
 	}
 }

--- a/stats_test.go
+++ b/stats_test.go
@@ -107,12 +107,12 @@ func TestUpdateStats(t *testing.T) {
 
 func TestUpdateOSStats(t *testing.T) {
 	oss := NewOSStats(1)
-	oss.updateOpenConns()
+	oss.updateOpenConns(Config{})
 }
 
 func BenchmarkUpdateOpenConns(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		oss := NewOSStats(1)
-		oss.updateOpenConns()
+		oss.updateOpenConns(Config{})
 	}
 }

--- a/stats_test.go
+++ b/stats_test.go
@@ -107,7 +107,7 @@ func TestUpdateStats(t *testing.T) {
 
 func TestUpdateOSStats(t *testing.T) {
 	oss := NewOSStats(1)
-	oss.updateOpenConns(Config{})
+	oss.updateOpenConns(Config{Exec: Exec{Concurrency: 3}})
 }
 
 func BenchmarkUpdateOpenConns(b *testing.B) {

--- a/util.go
+++ b/util.go
@@ -87,20 +87,14 @@ func ByteCountSI(b int64) string {
 }
 func PrintLogo() (int, error) {
 	return fmt.Printf("%v",
-		Cyan("\n    -===============-.").String()+Red("      .=.    .-.      ").String()+Cyan("-============--.  ").String()+
-			Cyan("\n  .======---======-").String()+Red("    .    ===   -==.").String()+Cyan("       .==============- ").String()+
-			Cyan("\n  =====    .=====.").String()+Red("    ==-.  -==  -==   .---.").String()+Cyan("   -====.   .====-").String()+
-			Cyan("\n  ====-    -====").String()+Red("       -==-  -=  --  .===-.").String()+Cyan("     -===-    -====").String()+
-			Cyan("\n  ====-    ====-").String()+Red("  ...    .--  -  -  --.").String()+Cyan("          ====    -====").String()+
-			Cyan("\n  =====    ====").String()+Red("   .-===-.. ....-").String()+Yellow("_").String()+Red("-... ..-=====.").String()+Cyan("  .===    -====").String()+
-			Cyan("\n  .============").String()+Red("       ...... =").String()+Yellow("//|\\\\").String()+Red("........").String()+Cyan("       ===    -====").String()+
-			Cyan("\n    -==========").String()+Red("     ........ -").String()+Yellow("\\\\|//").String()+Red(".     .-----.").String()+Cyan("  ===    -====").String()+
-			Cyan("\n           ====.").String()+Red("  -====--.  .. -").String()+Yellow("‾").String()+Red("-. --   ..-==.").String()+Cyan("  -===    -====").String()+
-			Cyan("\n           =====").String()+Red("         .--. .=  =  .==.").String()+Cyan("        ====    -====").String()+
-			Cyan("\n           -====-").String()+Red("     .-==-  .=-  ==   -==-").String()+Cyan("     ====-    -====").String()+
-			Cyan("\n            =====-").String()+Red("   .--.   .==.  ===   .--").String()+Cyan("   .=====.   .=====").String()+
-			Cyan("\n            -======-.").String()+Red("       ==-   -==").String()+Cyan("        -===============.").String()+
-			Cyan("\n             --------.").String()+Red("      ..     -.").String()+Cyan("       ---============-  ").String()+
+		Cyan("\n.=+++++++=.").String()+Red("      ,      ").String()+Cyan("=++++++==").String()+
+			Cyan("\n++=  .++.").String()+Red("    ))  ))  ))").String()+Cyan("   .++=  =+=").String()+
+			Cyan("\n++.  =+=").String()+Red("   )\\ \\\\ ǀǀ // /)").String()+Cyan("   +=  =++").String()+
+			Cyan("\n=++==++.").String()+Red("  ___\\\\ ").String()+Yellow("/‾‾\\").String()+Red(" '//__,").String()+Cyan(" ++  =++").String()+
+			Cyan("\n ..==++.").String()+Red(" '▔▔//' ").String()+Yellow("\\__/").String()+Red(" \\\\▔▔▔").String()+Cyan("  ++  =++").String()+
+			Cyan("\n     =+=").String()+Red("   (/ // ǀǀ \\\\ \\(").String()+Cyan("  .+=  =++").String()+
+			Cyan("\n     .++=").String()+Red("    ((  ((  ((").String()+Cyan("   .++=  =++").String()+
+			Cyan("\n      ====.").String()+Red("       '     ").String()+Cyan(" .=+=+++++=").String()+
 			"\n")
 }
 

--- a/util.go
+++ b/util.go
@@ -87,14 +87,14 @@ func ByteCountSI(b int64) string {
 }
 func PrintLogo() (int, error) {
 	return fmt.Printf("%v",
-		Cyan("\n.=+++++++=.").String()+Red("      ,      ").String()+Cyan("=++++++==").String()+
-			Cyan("\n++=  .++.").String()+Red("    ((  ((  ((").String()+Cyan("   .++=  =+=").String()+
-			Cyan("\n++.  =+=").String()+Red("   (\\ \\\\ ǀǀ // /)").String()+Cyan("   +=  =++").String()+
-			Cyan("\n=++==++.").String()+Red("  ___\\\\ ").String()+Yellow("/‾‾\\").String()+Red(" '//__,").String()+Cyan(" ++  =++").String()+
-			Cyan("\n ..==++.").String()+Red(" '▔▔//' ").String()+Yellow("\\__/").String()+Red(" \\\\▔▔▔").String()+Cyan("  ++  =++").String()+
-			Cyan("\n     =+=").String()+Red("   )/ // ǀǀ \\\\ \\)").String()+Cyan("  .+=  =++").String()+
-			Cyan("\n     .++=").String()+Red("    ))  ))  ))").String()+Cyan("   .++=  =++").String()+
-			Cyan("\n      ====.").String()+Red("       '    ").String()+Cyan(" =+=+++++=").String()+
+		Cyan("\n         .=+++++++=.").String()+Red("      ,_     ").String()+Cyan("=++++++==").String()+
+			Cyan("\n         ++=  .++.").String()+Red("    ((  ((  ((").String()+Cyan("   .++=  =+=").String()+
+			Cyan("\n         ++.  =+=").String()+Red("   (\\ \\\\ ǀǀ // /)").String()+Cyan("   +=  =++").String()+
+			Cyan("\n         =++==++.").String()+Red("  ___\\\\ ").String()+Yellow("/‾‾\\").String()+Red(" '//__,").String()+Cyan(" ++  =++").String()+
+			Cyan("\n          ..==++.").String()+Red(" '▔▔//' ").String()+Yellow("\\__/").String()+Red(" \\\\▔▔▔").String()+Cyan("  ++  =++").String()+
+			Cyan("\n              =+=").String()+Red("   )/ // ǀǀ \\\\ \\)").String()+Cyan("  .+=  =++").String()+
+			Cyan("\n              .++=").String()+Red("    ))  ))  ))").String()+Cyan("   .++=  =++").String()+
+			Cyan("\n               ====.").String()+Red("      ‾'    ").String()+Cyan(" =+=+++++=").String()+
 			"\n")
 }
 

--- a/util.go
+++ b/util.go
@@ -87,14 +87,15 @@ func ByteCountSI(b int64) string {
 }
 func PrintLogo() (int, error) {
 	return fmt.Printf("%v",
-		Cyan("\n         .=+++++++=.").String()+Red("      ,_     ").String()+Cyan("=++++++==").String()+
-			Cyan("\n         ++=  .++.").String()+Red("    ((  ((  ((").String()+Cyan("   .++=  =+=").String()+
-			Cyan("\n         ++.  =+=").String()+Red("   (\\ \\\\ ǀǀ // /)").String()+Cyan("   +=  =++").String()+
-			Cyan("\n         =++==++.").String()+Red("  ___\\\\ ").String()+Yellow("/‾‾\\").String()+Red(" '//__,").String()+Cyan(" ++  =++").String()+
-			Cyan("\n          ..==++.").String()+Red(" '▔▔//' ").String()+Yellow("\\__/").String()+Red(" \\\\▔▔▔").String()+Cyan("  ++  =++").String()+
-			Cyan("\n              =+=").String()+Red("   )/ // ǀǀ \\\\ \\)").String()+Cyan("  .+=  =++").String()+
-			Cyan("\n              .++=").String()+Red("    ))  ))  ))").String()+Cyan("   .++=  =++").String()+
-			Cyan("\n               ====.").String()+Red("      ‾'    ").String()+Cyan(" =+=+++++=").String()+
+		Cyan("\n        .╬╠╠╠╠╠╠╠╠╠╬`").String()+Red("     ╠╠  ,╬╠     ").String()+Cyan("╙╠╠╠╠╠╠╠╠╠φ").String()+
+			Cyan("\n        ╠╠╠╙   ╠╠╠╙").String()+Red("   ╠╬ε └╠ε ╠╩  ╔#▒  ").String()+Cyan("`╠╠╠   ╙╠╠╠").String()+
+			Cyan("\n        ╠╠╠   ]╠╠╩").String()+Red("     └╝▒ ╙Γ ╩ ╔╬╩`     ").String()+Cyan("╠╠ε   ╠╠╠").String()+
+			Cyan("\n        ╠╠╠ε  ╚╠╠").String()+Red("   ╝╠▒╗, \"╓δΘ╦\",╓φ▒╬╠▒ε ").String()+Cyan("╚╠▒   ╠╠╠").String()+
+			Cyan("\n         ╚╠╠╠╠╠╠╠").String()+Red("         ,╠(").String()+Yellow("⬤").String()+Red(" ╩≈╔╓╓╓,   ").String()+Cyan("]╠╠   ╠╠╠").String()+
+			Cyan("\n              ╠╠╠⌐").String()+Red(" ²╠╠╝╩\"²╓∩⌠╙╠`φ, `╙╝╠  ").String()+Cyan("╠╠╠   ╠╠╠").String()+
+			Cyan("\n              [╠╠╠ ").String()+Red("     ╓@╬  ╬ ╠ε ╙╠φ   ").String()+Cyan(",╠╠Γ   ╠╠╠").String()+
+			Cyan("\n               ╠╠╠▒").String()+Red("  '╝╩\" .╬╠ ]╠ε  ╚╩  ").String()+Cyan("╔╠╠╠   ╓╠╠╠").String()+
+			Cyan("\n               ╚╠╠╠╠φ,").String()+Red("    ╠╩   ╠╛     ").String()+Cyan("φ╠╠╠╠╠╠╠╠╠╩").String()+
 			"\n")
 }
 

--- a/util.go
+++ b/util.go
@@ -88,12 +88,12 @@ func ByteCountSI(b int64) string {
 func PrintLogo() (int, error) {
 	return fmt.Printf("%v",
 		Cyan("\n.=+++++++=.").String()+Red("      ,      ").String()+Cyan("=++++++==").String()+
-			Cyan("\n++=  .++.").String()+Red("    ))  ))  ))").String()+Cyan("   .++=  =+=").String()+
-			Cyan("\n++.  =+=").String()+Red("   )\\ \\\\ ǀǀ // /)").String()+Cyan("   +=  =++").String()+
+			Cyan("\n++=  .++.").String()+Red("    ((  ((  ((").String()+Cyan("   .++=  =+=").String()+
+			Cyan("\n++.  =+=").String()+Red("   (\\ \\\\ ǀǀ // /)").String()+Cyan("   +=  =++").String()+
 			Cyan("\n=++==++.").String()+Red("  ___\\\\ ").String()+Yellow("/‾‾\\").String()+Red(" '//__,").String()+Cyan(" ++  =++").String()+
 			Cyan("\n ..==++.").String()+Red(" '▔▔//' ").String()+Yellow("\\__/").String()+Red(" \\\\▔▔▔").String()+Cyan("  ++  =++").String()+
-			Cyan("\n     =+=").String()+Red("   (/ // ǀǀ \\\\ \\(").String()+Cyan("  .+=  =++").String()+
-			Cyan("\n     .++=").String()+Red("    ((  ((  ((").String()+Cyan("   .++=  =++").String()+
+			Cyan("\n     =+=").String()+Red("   )/ // ǀǀ \\\\ \\)").String()+Cyan("  .+=  =++").String()+
+			Cyan("\n     .++=").String()+Red("    ))  ))  ))").String()+Cyan("   .++=  =++").String()+
 			Cyan("\n      ====.").String()+Red("       '     ").String()+Cyan(" .=+=+++++=").String()+
 			"\n")
 }

--- a/util.go
+++ b/util.go
@@ -94,7 +94,7 @@ func PrintLogo() (int, error) {
 			Cyan("\n ..==++.").String()+Red(" '▔▔//' ").String()+Yellow("\\__/").String()+Red(" \\\\▔▔▔").String()+Cyan("  ++  =++").String()+
 			Cyan("\n     =+=").String()+Red("   )/ // ǀǀ \\\\ \\)").String()+Cyan("  .+=  =++").String()+
 			Cyan("\n     .++=").String()+Red("    ))  ))  ))").String()+Cyan("   .++=  =++").String()+
-			Cyan("\n      ====.").String()+Red("       '     ").String()+Cyan(" .=+=+++++=").String()+
+			Cyan("\n      ====.").String()+Red("       '    ").String()+Cyan(" =+=+++++=").String()+
 			"\n")
 }
 


### PR DESCRIPTION
- showing open network conns
- removed all open conns. The PID cannot know this fact about the OS and it's too ambitious, i.e. it'll just be wrong and result in WTF comments.
- version 0.2.6
- updated ascii art
- updated ascii art
- v0.2.7
- added max conns to live log
- shorter run for formpost_multipart
- more logo updates
- even more logo updates
- now staggering on and offramp for doReqAtmpt threads. it gives the remote API the tiniest bit of time to warm up but also lets us watch on the CLI
- refactored methods to make them easier to read. all init routines use init, etc.
- added pooling and draining period
- combined threads and connections into 'concurrency'. This makes p0d more usable as you can't configure it with less threads than connections. In honesty, users don't care they probably just want concurrency
- label
- label for ramping up. connection timeout is now 1s hardcoded to support draining which was lagging
- added max values for read, write throughput and roundtrip throughput. these are not always at the end end of the run, so monitor them separately. also this is what users want for bragging rights, so it's now Magenta
- outfile
- TimerPhase
- added ramp time calculation as 10% of total runtime, otherwise as specified. total runtime now cannot be less than 3s to prevent crazy behaviour with small ramps and UI live updates.
- added timerphases to control ramp up and ramp down
- fixed HTTP/2 connection re-use issue that made p0d unintuitive to use. HTTP/2 multiplexes requests on one connection using streams. This is undesirable for performance testing where we default to stress the remote servers ability to handle connections.
- default 3 second ramp
- added TimerPhase set method to upgrade TimerPhase
- fixed bug where setTimerPhase did not work because of leftover code
- Main update is now only setting Main TimerPhase when rampup has reached max concurrency. Otherwise the test will be stuck in rampup phase until rampdown. This is what we want, it gives the user live feedback that their test is not working
- now parsing URLs during config to validate.
- added mutex to OSS stats access to prevent race conditions
- added mutex to OSS stats access to prevent race conditions
- debug code for centos
- debug code for centos
- reverted debug code for centos
- new model where all connections are exclusive to threads
