### PR TITLE
24

### DIFF
--- a/p0d.go
+++ b/p0d.go
@@ -254,7 +254,7 @@ Main:
 		}
 	}
 	p.setTimerPhase(Done)
-	log(Cyan("done").String())
+	log(Cyan("exiting").String())
 }
 
 func (p *P0d) initReqAtmpts(ras chan ReqAtmpt) {


### PR DESCRIPTION
- fixed bug uilive was scrolling up swallowing previous lines, replaced with forked lib. neat trick with replace directive in go.mod
- logo
- exiting
