### PR TITLE
45

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,9 +16,11 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15 // indirect
+	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/showwin/speedtest-go v1.1.5 // indirect
+	github.com/spenczar/tdigest v2.1.0+incompatible // indirect
 	github.com/weaveworks/procspy v0.0.0-20150706124340-cb970aa190c3 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafo
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15 h1:AUNCr9CiJuwrRYS3XieqF+Z9B9gNxo/eANAJCF2eiN4=
 github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -24,6 +25,8 @@ github.com/showwin/speedtest-go v1.1.5 h1:dud1cS2Qppbm50BrTKzrBj78wY78ORL5LIiRjK
 github.com/showwin/speedtest-go v1.1.5/go.mod h1:dJugxvC/AQDt4HQQKZ9lKNa2+b1c8nzj9IL0a/F8l1U=
 github.com/simonmittag/procspy v0.0.0-20191119070947-e8cf3f846a67 h1:2vdAWuq0Bz3r4hu/1il3b6r40GtPu/CpOVy4mdd5u0s=
 github.com/simonmittag/procspy v0.0.0-20191119070947-e8cf3f846a67/go.mod h1:HUFk0D2ql6u0y8MaqlKQQty3NqIZGe/SvQt7D8QS5Ok=
+github.com/spenczar/tdigest v2.1.0+incompatible h1:fW2Amo+VWvKXzANU0TyeOGi3xS0jDcM8y5gC5CHhSHM=
+github.com/spenczar/tdigest v2.1.0+incompatible/go.mod h1:taEJf1IAhnY3KPrPBSUP4dNFwy4XSWs83kbY/FzdtSU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/weaveworks/procspy v0.0.0-20150706124340-cb970aa190c3 h1:UC4iN/yCDCObTBhKzo34/R2U6qptTPmqbzG6UiQVMUQ=

--- a/p0d.go
+++ b/p0d.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gosuri/uilive"
 	"github.com/hako/durafmt"
 	. "github.com/logrusorgru/aurora"
-	"github.com/spenczar/tdigest"
 	"io"
 	"io/ioutil"
 	"math"
@@ -184,7 +183,7 @@ func NewP0d(cfg Config, ulimit int64, outputFile string, durationSecs int, inter
 		ReqStats: &ReqStats{
 			ErrorTypes:                   make(map[string]int),
 			Sample:                       NewSample(),
-			ElpsdAtmptLatencyNsQuantiles: tdigest.New(),
+			ElpsdAtmptLatencyNsQuantiles: NewQuantile(),
 		},
 		Output:      outputFile,
 		Interrupted: false,
@@ -818,7 +817,7 @@ func (p *P0d) doLogLive() {
 
 	i++
 
-	convertToMs := func(q *tdigest.TDigest, v float64) string {
+	convertToMs := func(q *Quantile, v float64) string {
 		qv := q.Quantile(v)
 		if math.IsNaN(qv) {
 			qv = 0

--- a/p0d.go
+++ b/p0d.go
@@ -183,7 +183,7 @@ func NewP0d(cfg Config, ulimit int64, outputFile string, durationSecs int, inter
 		ReqStats: &ReqStats{
 			ErrorTypes:                   make(map[string]int),
 			Sample:                       NewSample(),
-			ElpsdAtmptLatencyNsQuantiles: NewQuantile(),
+			ElpsdAtmptLatencyNsQuantiles: NewQuantileWithCompression(500),
 		},
 		Output:      outputFile,
 		Interrupted: false,

--- a/p0d.go
+++ b/p0d.go
@@ -819,7 +819,11 @@ func (p *P0d) doLogLive() {
 	i++
 
 	convertToMs := func(q *tdigest.TDigest, v float64) string {
-		c := time.Duration(int64(q.Quantile(v)))
+		qv := q.Quantile(v)
+		if math.IsNaN(qv) {
+			qv = 0
+		}
+		c := time.Duration(int64(qv))
 		if c.Milliseconds() == 0 {
 			return FGroup(c.Microseconds()) + "μs"
 		} else {
@@ -929,7 +933,7 @@ func (p *P0d) outFileRequestAttempt(ra ReqAtmpt, prefix string, indent string, c
 func (p *P0d) initOSStats(done chan struct{}) {
 	p.OS.PID = os.Getpid()
 	if !p.Config.Exec.SkipInetTest {
-		go p.getOSINetSpeed(18)
+		go p.getOSINetSpeed(30)
 	}
 	_, p.OS.LimitOpenFiles = getUlimit()
 	p.OS.LimitRAMBytes = getRAMBytes()

--- a/stats.go
+++ b/stats.go
@@ -65,7 +65,7 @@ func NewQuantile() *Quantile {
 	}
 }
 
-func NewWithCompression(compression float64) *Quantile {
+func NewQuantileWithCompression(compression float64) *Quantile {
 	return &Quantile{
 		t: tdigest.NewWithCompression(compression),
 	}

--- a/stats_test.go
+++ b/stats_test.go
@@ -10,9 +10,10 @@ func TestUpdateStats(t *testing.T) {
 	cfg := Config{Res: Res{Code: 200}}
 
 	s := ReqStats{
-		ReqAtmpts:  11,
-		Start:      time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
-		ErrorTypes: make(map[string]int),
+		ReqAtmpts:                    11,
+		Start:                        time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+		ErrorTypes:                   make(map[string]int),
+		ElpsdAtmptLatencyNsQuantiles: NewQuantile(),
 	}
 
 	g := ReqAtmpt{


### PR DESCRIPTION
- added t-digest implementation for percentiles of latency
- checking for NaN to prevent issues when live reporting starts
- wrapped quantiles so i can JSON serialise it
- bugfix where ReqStats wasn't initialized for test
- changed compression for quantiles to 500 so accuracy is better for large test runs. author recommends 500 for more than one million records.
